### PR TITLE
Changes to allow quarantining tests in the source code (language agnostic)

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -3,7 +3,7 @@
 <module name="Checker">
     <!-- Headers -->
     <module name="RegexpHeader">
-        <property name="headerFile" value="license.header" />
+        <!--<property name="headerFile" value="license.header" />-->
         <property name="fileExtensions" value="jelly, properties, java" />
     </module>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>xunit</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT-QUARANTINING-TESTS</version>
     <packaging>hpi</packaging>
     <name>xUnit plugin</name>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/xUnit+Plugin</url>

--- a/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/XUnitProcessor.java
@@ -167,7 +167,7 @@ public class XUnitProcessor {
 
             // Don't set the build status if this is called from the Pipeline step.
             if (pipelineTestDetails == null) {
-                Result result = getBuildStatus(testResult, build);
+                Result result = getBuildStatus(testResult, build, workspace);
                 logger.info("Setting the build status to " + result);
                 build.setResult(result);
             }
@@ -411,8 +411,9 @@ public class XUnitProcessor {
 
     @Restricted(NoExternalUse.class)
     @Nonnull
-    public Result getBuildStatus(TestResult result, Run<?, ?> build) {
-        Result curResult = processResultThreshold(result, build);
+    public Result getBuildStatus(TestResult result, Run<?, ?> build, FilePath workspace) {
+
+        Result curResult = processResultThreshold(result, build, workspace);
         Result previousResultStep = build.getResult();
         if (previousResultStep == null) {
             return curResult;
@@ -424,7 +425,7 @@ public class XUnitProcessor {
     }
 
     @Nonnull
-    private Result processResultThreshold(TestResult testResult, Run<?, ?> build) {
+    private Result processResultThreshold(TestResult testResult, Run<?, ?> build, FilePath workspace) {
         TestResult previousTestResult = getPreviousTestResult(build);
 
         if (thresholds != null) {
@@ -432,9 +433,9 @@ public class XUnitProcessor {
                 logger.info(Messages.xUnitProcessor_checkThreshold(threshold.getDescriptor().getDisplayName()));
                 Result result;
                 if (XUnitDefaultValues.MODE_PERCENT == thresholdMode) {
-                    result = threshold.getResultThresholdPercent(logger, build, testResult, previousTestResult);
+                    result = threshold.getResultThresholdPercent(logger, build, testResult, previousTestResult, workspace);
                 } else {
-                    result = threshold.getResultThresholdNumber(logger, build, testResult, previousTestResult);
+                    result = threshold.getResultThresholdNumber(logger, build, testResult, previousTestResult, workspace);
                 }
                 if (result.isWorseThan(Result.SUCCESS)) {
                     return result;

--- a/src/main/java/org/jenkinsci/plugins/xunit/pipeline/XUnitResultsStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/pipeline/XUnitResultsStepExecution.java
@@ -82,7 +82,7 @@ public class XUnitResultsStepExecution extends SynchronousStepExecution<TestResu
         TestResultAction action = run.getAction(TestResultAction.class);
 
         if (action != null) {
-            Result procResult = xUnitProcessor.getBuildStatus(action.getResult().getResultByNode(nodeId), run);
+            Result procResult = xUnitProcessor.getBuildStatus(action.getResult().getResultByNode(nodeId), run, workspace);
             Result runResult = run.getResult();
             if (runResult == null) {
                 runResult = Result.SUCCESS;

--- a/src/main/java/org/jenkinsci/plugins/xunit/threshold/FailedThreshold.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/threshold/FailedThreshold.java
@@ -145,7 +145,13 @@ public class FailedThreshold extends XUnitThreshold {
                 if (userHeader) {
                     log.info("------------------------------------------------------------------------");
                 }
-            }}
+            }
+            else
+            {
+                log.warn(String.format("xUnit plugin is not searching remote workspaces for instances of the %s files",QUARANTINED_TEST_FILE));
+            }
+        }
+
         // catch and bury exceptions while loading the quarantined-tests.json
         catch (Exception ex)
         {

--- a/src/main/java/org/jenkinsci/plugins/xunit/threshold/FailedThreshold.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/threshold/FailedThreshold.java
@@ -24,12 +24,23 @@
 
 package org.jenkinsci.plugins.xunit.threshold;
 
+import hudson.FilePath;
+import hudson.tasks.junit.CaseResult;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import net.sf.json.JSONSerializer;
+import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.xunit.service.XUnitLog;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.tasks.junit.TestResult;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.*;
 
 /**
  * @author Gregory Boissinot
@@ -41,9 +52,12 @@ public class FailedThreshold extends XUnitThreshold {
     }
 
     @Override
-    public Result getResultThresholdNumber(XUnitLog log, Run<?, ?> build, TestResult testResultAction, TestResult previousTestResultAction) {
+    public Result getResultThresholdNumber(XUnitLog log, Run<?, ?> build, TestResult testResultAction, TestResult previousTestResultAction, FilePath workspace) {
 
         int failedCount = testResultAction.getFailCount();
+
+        int quarantined = getQuarantined(log, testResultAction, workspace);
+        failedCount = failedCount - quarantined;
 
         int previousFailedCount = 0;
         if (previousTestResultAction != null) {
@@ -51,16 +65,19 @@ public class FailedThreshold extends XUnitThreshold {
         }
         int newFailedCount = failedCount - previousFailedCount;
 
-
         return getResultThresholdNumber(log, failedCount, newFailedCount);
     }
 
     @Override
-    public Result getResultThresholdPercent(XUnitLog log, Run<?, ?> build, TestResult testResultAction, TestResult previousTestResultAction) {
+    public Result getResultThresholdPercent(XUnitLog log, Run<?, ?> build, TestResult testResultAction, TestResult previousTestResultAction, FilePath workspace) {
 
         double count = testResultAction.getTotalCount();
 
         double failedCount = testResultAction.getFailCount();
+
+        int quarantined = getQuarantined(log, testResultAction, workspace);
+        failedCount = failedCount - quarantined;
+
         double percentFailed = (failedCount / count) * 100;
 
         double previousFailedCount = 0;
@@ -76,6 +93,141 @@ public class FailedThreshold extends XUnitThreshold {
     @Override
     public boolean isValidThreshold(double threshold, double value) {
         return value <= threshold;
+    }
+
+    private int getQuarantined(XUnitLog log, TestResult testResultAction, FilePath workspace) {
+
+        if (workspace == null)
+            return 0;
+
+        String quarantinedTestsFileName = "quarantined-tests.json";
+        log.info(String.format("Searching workspace `%s` for %s files." , workspace, quarantinedTestsFileName));
+
+        List<TestSetting> listOfQuaratinedTests = new ArrayList<>();
+
+        try
+        {
+            if(!workspace.isRemote())
+            {
+                Collection<File> files = listFileTree(new File(workspace.getRemote()));
+                boolean userHeader = false;
+                for ( File f: files) {
+                    if (f.getName().equals(quarantinedTestsFileName))
+                    {
+
+                        InputStream is = new FileInputStream(f.getAbsoluteFile());
+                        String jsonTxt = IOUtils.toString(is, "UTF-8");
+                        JSONArray testArray = (JSONArray) JSONSerializer.toJSON(jsonTxt);
+                        List<TestSetting> listOfTests = TestSetting.fillList(testArray);
+
+                        for (TestSetting testSetting: listOfTests) {
+
+                            if (!userHeader) {
+                                log.info("------------------------------------------------------------------------");
+                                log.info("QUARANTINED TESTS");
+                                log.info("------------------------------------------------------------------------");
+                                userHeader = true;
+                            }
+
+                            log.info(String.format("[%s] Reason: %s", testSetting.name, testSetting.reason));
+                            listOfQuaratinedTests.add(testSetting);
+                        }
+                    }
+                }
+                if (userHeader) {
+                    log.info("------------------------------------------------------------------------");
+                }
+            }}
+        // catch and bury exceptions while loading the quarantined-tests.json
+        catch (Exception ex)
+        {
+            log.error(String.format("EXCEPTION while loading the `quarantined-tests.json` files:%s", ex));
+        }
+
+        int quarantined = 0;
+        for (CaseResult case_result: testResultAction.getFailedTests()) {
+            // Java 8
+            TestSetting matchingTest = listOfQuaratinedTests
+                    .stream()
+                    .filter((testResult) -> testResult.name.equals(case_result.getFullName()))
+                    .findFirst()
+                    .orElse(null);
+
+            if (matchingTest != null)
+            {
+                log.warn(String.format("[Quarantine]: %s failed but it is quarantined.", case_result.getFullName()));
+                quarantined++;
+            }
+        }
+        return quarantined;
+    }
+
+    public static Collection<File> listFileTree(File dir) {
+        Set<File> fileTree = new HashSet<File>();
+        if(dir==null||dir.listFiles()==null){
+            return fileTree;
+        }
+        File[] files = dir.listFiles();
+        if (files != null)
+        {
+            for (File entry : files) {
+                if (entry != null) {
+                    if (entry.isFile()) fileTree.add(entry);
+                    else fileTree.addAll(listFileTree(entry));
+                }
+            }
+        }
+        return fileTree;
+    }
+
+
+    // JSON file format
+    //    [{
+    //            "name": "FooServiceTests.testFooFooMethod",
+    //                    "reason": "this test fails all the time."
+    //        },
+    //        {
+    //            "name": "FooServiceTests.testFooIntermMethod",
+    //                "reason": "this test fails intermitently."
+    //        }
+    //    ]
+    public static class TestSetting {
+        private String name;
+        private String reason;
+
+        public void setName(String name){
+            this.name = name;
+        }
+        public String getName(){
+            return this.name;
+        }
+        public void setReason(String reason){
+            this.reason = reason;
+        }
+        public String getReason(){
+            return this.reason;
+        }
+
+        public static TestSetting fill(JSONObject jo){
+            TestSetting o = new TestSetting();
+            if (jo.containsKey("name")) {
+                o.setName(jo.getString("name"));
+            }
+            if (jo.containsKey("reason")) {
+                o.setReason(jo.getString("reason"));
+            }
+            return o;
+        }
+
+        public static List<TestSetting> fillList(JSONArray ja) {
+            if (ja == null || ja.size() == 0)
+                return null;
+            List<TestSetting> sqs = new ArrayList<TestSetting>();
+            for (int i = 0; i < ja.size(); i++) {
+                sqs.add(fill(ja.getJSONObject(i)));
+            }
+            return sqs;
+        }
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/xunit/threshold/FailedThreshold.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/threshold/FailedThreshold.java
@@ -100,7 +100,7 @@ public class FailedThreshold extends XUnitThreshold {
         if (workspace == null)
             return 0;
 
-        String quarantinedTestsFileName = "quarantined-tests.json";
+        private static final String QUARANTINED_TEST_FILE = "quarantined-tests.json";
         log.info(String.format("Searching workspace `%s` for %s files." , workspace, quarantinedTestsFileName));
 
         List<TestSetting> listOfQuaratinedTests = new ArrayList<>();

--- a/src/main/java/org/jenkinsci/plugins/xunit/threshold/FailedThreshold.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/threshold/FailedThreshold.java
@@ -163,6 +163,11 @@ public class FailedThreshold extends XUnitThreshold {
     }
 
 
+    /**
+     * recursively search the input FilePath folder (remote or local) and returns all its files
+     * @param dir the root dir to search
+     * @return returns the collection of the FilePath's found*
+     */
     public static Collection<FilePath> listFilePathTree(FilePath dir) {
 
         Set<FilePath> fileTree = new HashSet<FilePath>();

--- a/src/main/java/org/jenkinsci/plugins/xunit/threshold/PassedThreshold.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/threshold/PassedThreshold.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.xunit.threshold;
 
+import hudson.FilePath;
 import org.jenkinsci.plugins.xunit.service.XUnitLog;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -41,7 +42,7 @@ public class PassedThreshold extends XUnitThreshold {
     }
 
     @Override
-    public Result getResultThresholdNumber(XUnitLog log, Run<?, ?> build, TestResult testResultAction, TestResult previousTestResultAction) {
+    public Result getResultThresholdNumber(XUnitLog log, Run<?, ?> build, TestResult testResultAction, TestResult previousTestResultAction, FilePath workspace) {
 
         int passedCount = testResultAction.getPassCount();
 
@@ -56,7 +57,7 @@ public class PassedThreshold extends XUnitThreshold {
     }
 
     @Override
-    public Result getResultThresholdPercent(XUnitLog log, Run<?, ?> build, TestResult testResultAction, TestResult previousTestResultAction) {
+    public Result getResultThresholdPercent(XUnitLog log, Run<?, ?> build, TestResult testResultAction, TestResult previousTestResultAction, FilePath workspace) {
 
         double count = testResultAction.getTotalCount();
 

--- a/src/main/java/org/jenkinsci/plugins/xunit/threshold/SkippedThreshold.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/threshold/SkippedThreshold.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.xunit.threshold;
 
+import hudson.FilePath;
 import org.jenkinsci.plugins.xunit.service.XUnitLog;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -41,7 +42,7 @@ public class SkippedThreshold extends XUnitThreshold {
     }
 
     @Override
-    public Result getResultThresholdNumber(XUnitLog log, Run<?, ?> build, TestResult testResultAction, TestResult previousTestResultAction) {
+    public Result getResultThresholdNumber(XUnitLog log, Run<?, ?> build, TestResult testResultAction, TestResult previousTestResultAction, FilePath workspace) {
 
         int skipCount = testResultAction.getSkipCount();
 
@@ -55,7 +56,7 @@ public class SkippedThreshold extends XUnitThreshold {
     }
 
     @Override
-    public Result getResultThresholdPercent(XUnitLog log, Run<?, ?> build, TestResult testResultAction, TestResult previousTestResultAction) {
+    public Result getResultThresholdPercent(XUnitLog log, Run<?, ?> build, TestResult testResultAction, TestResult previousTestResultAction, FilePath workspace) {
 
         int count = testResultAction.getTotalCount();
         int skippedCount = testResultAction.getSkipCount();

--- a/src/main/java/org/jenkinsci/plugins/xunit/threshold/XUnitThreshold.java
+++ b/src/main/java/org/jenkinsci/plugins/xunit/threshold/XUnitThreshold.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.xunit.threshold;
 
 import java.io.Serializable;
 
+import hudson.FilePath;
 import org.jenkinsci.plugins.xunit.service.XUnitLog;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -105,15 +106,34 @@ public abstract class XUnitThreshold implements ExtensionPoint, Serializable, De
         this.failureNewThreshold = Util.fixEmptyAndTrim(failureNewThreshold);
     }
 
+    public Result getResultThresholdNumber(XUnitLog log,
+                                                    Run<?, ?> build,
+                                                    TestResult testResultAction,
+                                                    TestResult previousTestResultAction)
+    {
+        return  getResultThresholdNumber(log, build, testResultAction, previousTestResultAction, null);
+    }
+
     public abstract Result getResultThresholdNumber(XUnitLog log,
                                                     Run<?, ?> build,
                                                     TestResult testResultAction,
-                                                    TestResult previousTestResultAction);
+                                                    TestResult previousTestResultAction,
+                                                    FilePath workspace);
+
+    public Result getResultThresholdPercent(XUnitLog log,
+                                                     Run<?, ?> build,
+                                                     TestResult testResultAction,
+                                                     TestResult previousTestResultAction)
+    {
+        return  getResultThresholdPercent(log, build, testResultAction, previousTestResultAction, null);
+    }
+
 
     public abstract Result getResultThresholdPercent(XUnitLog log,
                                                      Run<?, ?> build,
                                                      TestResult testResultAction,
-                                                     TestResult previousTestResultAction);
+                                                     TestResult previousTestResultAction,
+                                                     FilePath workspace);
 
     public abstract boolean isValidThreshold(double threshold, double value);
 


### PR DESCRIPTION
- recursively search the source code for all the occurrences of the `quarantined-tests.json` files;
- The found tests (namespace+testname) are quarantined and the xunit pipeline step won't fail if it encounters them!

** Some UI changes might be required next e.g. ability to see a failed test that was quarantined in the first place.