### PR TITLE
Increase the SUREFIRE_TIME precision to 20 decimals to fix helm tests output

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:simpleType name="SUREFIRE_TIME">
         <xs:restriction base="xs:string">
-            <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*(\.[0-9]{0,18})?"/>
+            <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*(\.[0-9]{0,20})?"/>
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
Increase the SUREFIRE_TIME precision to 20 decimals to fix helm tests output.